### PR TITLE
Extra options in the set curve operation

### DIFF
--- a/edgeloop.py
+++ b/edgeloop.py
@@ -96,7 +96,7 @@ class Loop():
         ring = self.edge_rings[edge]
         return (ring[0], ring[len(ring) - 1])
 
-    def set_curve_flow(self, tension, use_rail):
+    def set_curve_flow(self, tension, use_rail, rail_type, rail_start, rail_end):
         count = len(self.edges)
         if count < 2 or self.is_cyclic:
             return
@@ -214,14 +214,18 @@ class Loop():
         #     dir1 = find_direction(start_vert, self.edges[0])
         #     dir2 = find_direction(end_vert, self.edges[-1])
         
-        dir1 = self.edges[0].other_vert(start_vert).co - start_vert.co
-        dir1 = dir1.normalized()
-        dir2 = self.edges[-1].other_vert(end_vert).co - end_vert.co
-        dir2 = dir2.normalized()
+        dir1_unnormalized = self.edges[0].other_vert(start_vert).co - start_vert.co
+        dir1 = dir1_unnormalized.normalized()
+        dir2_unnormalized = self.edges[-1].other_vert(end_vert).co - end_vert.co
+        dir2 = dir2_unnormalized.normalized()
 
         if use_rail:
-            p1 = self.edges[0].other_vert(start_vert).co
-            p4 = self.edges[-1].other_vert(end_vert).co
+            if rail_type == 'ABSOLUTE':
+                p1 = start_vert.co + dir1 * rail_start
+                p4 = end_vert.co + dir2 * rail_end
+            else: # == 'FACTOR'
+                p1 = start_vert.co + dir1_unnormalized * rail_start
+                p4 = end_vert.co + dir2_unnormalized * rail_end
         else:
             p1 = start_vert.co
             p4 = end_vert.co
@@ -232,21 +236,21 @@ class Loop():
         p2 = p1 + (dir1 * scale)
         p3 = p4 + (dir2 * scale)
          
-        #add_debug_verts = False
-        #if add_debug_verts:
-        #    # bmesh.ops.create_vert(self.bm, co=p1)
-        #    # bmesh.ops.create_vert(self.bm, co=p4)
+        # add_debug_verts = False
+        # if add_debug_verts:
+        #    bmesh.ops.create_vert(self.bm, co=p1)
+        #    bmesh.ops.create_vert(self.bm, co=p4)
         #    bmesh.ops.create_vert(self.bm, co=p2)
         #    bmesh.ops.create_vert(self.bm, co=p3)
        
         spline_points = []
-        precision = 1000      
+        precision = 1000
         spline_points = mathutils.geometry.interpolate_bezier(p1, p2, p3, p4, precision)
 
-        if use_rail:
-            map_segment_onto_spline(self.verts[1:-1], spline_points)
-        else:
-            map_segment_onto_spline(self.verts, spline_points)
+        # if use_rail:
+        #     map_segment_onto_spline(self.verts[1:-1], spline_points)
+        # else:
+        map_segment_onto_spline(self.verts, spline_points)
 
 
 

--- a/edgeloop.py
+++ b/edgeloop.py
@@ -247,9 +247,6 @@ class Loop():
         precision = 1000
         spline_points = mathutils.geometry.interpolate_bezier(p1, p2, p3, p4, precision)
 
-        # if use_rail:
-        #     map_segment_onto_spline(self.verts[1:-1], spline_points)
-        # else:
         map_segment_onto_spline(self.verts, spline_points)
 
 


### PR DESCRIPTION
This PR adds extra options in the set curve operation.
<img width="317" alt="image 1" src="https://github.com/user-attachments/assets/24f752aa-fcdc-45c6-913d-2c0504930a8c" />

The rail start and rail end options could be used to change how long the edge rail is, so that it is more versatile. One of the applications is adjusting bevel widths:

(before set curve)
<img width="478" alt="A wide bevel" src="https://github.com/user-attachments/assets/23cb234a-405e-4593-9d4a-b259d8dc264e" />

(after set curve)
<img width="478" alt="A tighter bevel" src="https://github.com/user-attachments/assets/6c2edfc8-a4cb-43b8-a386-286c6eb021c4" />

As you can see, the bevel becomes tighter after the operation; you can adjust it to become wider as well.

Another application is to fix overshot insets (aka unf*cking the inset, as named in the Meshmachin3 addon):

(before)
<img width="478" alt="overshot insets, creates artefacts" src="https://github.com/user-attachments/assets/00aea0a0-d8fd-49d5-8610-ba69fb38de62" />

(after)
<img width="478" alt="fixed" src="https://github.com/user-attachments/assets/5850243e-7ae4-40ee-ace6-f8597c9cd58c" />

Sidenote: There seems to be a bug that occasionally shows up that says something about bmeshes and bmverts not existing. I think this bug was present before this PR though.