### PR TITLE
Calculate rail_start and end from the other side + remove soft_min on absolute mode

### DIFF
--- a/edgeloop.py
+++ b/edgeloop.py
@@ -221,8 +221,8 @@ class Loop():
 
         if use_rail:
             if rail_type == 'ABSOLUTE':
-                p1 = start_vert.co + dir1 * rail_start
-                p4 = end_vert.co + dir2 * rail_end
+                p1 = start_vert.co + (dir1_unnormalized - dir1 * rail_start)
+                p4 = end_vert.co + (dir2_unnormalized - dir2 * rail_end)
             else: # == 'FACTOR'
                 p1 = start_vert.co + dir1_unnormalized * rail_start
                 p4 = end_vert.co + dir2_unnormalized * rail_end

--- a/op_set_edge_curve.py
+++ b/op_set_edge_curve.py
@@ -23,8 +23,8 @@ class SetEdgeCurveOP(bpy.types.Operator, op_set_edge_flow.SetEdgeLoopBase):
 
     use_rail : BoolProperty(name="Use Rail", default=False, description="The first and last edge stay in place")
     rail_mode: bpy.props.EnumProperty(name="Rail Mode", items=rail_mode, default=2, description="Switch rail mode between using absolute units or a factor of the length of the edge")
-    rail_start_width : FloatProperty(name="Rail Start", default=1.0, soft_min=0.0, subtype='DISTANCE', description="Choose how long the rail is at the start")
-    rail_end_width : FloatProperty(name="Rail End", default=1.0, soft_min=0.0, subtype='DISTANCE', description="Choose how long the rail is at the end")
+    rail_start_width : FloatProperty(name="Rail Start", default=1.0, subtype='DISTANCE', description="Choose how long the rail is at the start")
+    rail_end_width : FloatProperty(name="Rail End", default=1.0, subtype='DISTANCE', description="Choose how long the rail is at the end")
     rail_start_factor : FloatProperty(name="Rail Start", default=1.0, soft_min=0.0, soft_max=1.5, subtype='FACTOR', description="Choose how long the rail is at the start")
     rail_end_factor : FloatProperty(name="Rail End", default=1.0, soft_min=0.0, soft_max=1.5, subtype='FACTOR', description="Choose how long the rail is at the end")
    


### PR DESCRIPTION
I realized I had some oversights creating my previous PR, so this is to address those.

First, the soft_min of 0 on the rail_start and end options on absolute mode are removed, so that the user can make the bevel tighter. 

Secondly, the rail_start and end values are now specify the rail amount from the inside side – it's a bit hard to explain. I'll make a quick diagram.
<img width="468" alt="Screenshot 2025-02-21 at 9 35 27 am" src="https://github.com/user-attachments/assets/c996319d-6ffb-477f-a786-13d55be15a4c" />
Where the arrows are pointing that is what the rail amount is now, as opposed to previously where it specified the amount on the other side. Basically, now users can specify bevels of constant size, because previously if the start and end edges had uneven length the bevel would be "messed up". 

If users want to have the bevel "messed up" (which can be used to create variable width bevels), that functionality is preserved with the factor option.
